### PR TITLE
Indicate that the fork is used by suffixing the author

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -6,7 +6,7 @@ score=n
 
 [ODOOLINT]
 readme-template-url="https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"
-manifest-required-authors=OpenG2P
+manifest-required-authors=OpenG2P (OpenSPP fork)
 manifest-required-keys=license
 manifest-deprecated-keys=description,active
 license-allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3,Other OSI approved licence

--- a/.pylintrc-mandatory
+++ b/.pylintrc-mandatory
@@ -5,7 +5,7 @@ score=n
 
 [ODOOLINT]
 readme-template-url="https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"
-manifest-required-authors=OpenG2P
+manifest-required-authors=OpenG2P (OpenSPP fork)
 manifest-required-keys=license
 manifest-deprecated-keys=description,active
 license-allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3,Other OSI approved licence

--- a/README.md
+++ b/README.md
@@ -21,44 +21,44 @@ Available addons
 ----------------
 addon | version | maintainers | summary
 --- | --- | --- | ---
-[g2p_auth_id_oidc](g2p_auth_id_oidc/) | 17.0.0.0.0 |  | G2P Auth: OIDC - Reg ID
-[g2p_auth_oidc](g2p_auth_oidc/) | 17.0.0.0.0 |  | OpenID Connect Authentication
-[g2p_bank](g2p_bank/) | 17.0.0.0.0 |  | G2P Registry: Bank Details
-[g2p_bank_rest_api](g2p_bank_rest_api/) | 17.0.0.0.0 |  | G2P Registry: Bank Details Rest API
-[g2p_change_log](g2p_change_log/) | 17.0.0.0.0 |  | OpenG2P Change Log
-[g2p_disable_password_login](g2p_disable_password_login/) | 17.0.0.0.0 |  | Disable Password Login
-[g2p_documents](g2p_documents/) | 17.0.0.0.0 |  | G2P Documents Store
-[g2p_encryption](g2p_encryption/) | 17.0.0.0.0 |  | G2P Encryption: Base
-[g2p_encryption_keymanager](g2p_encryption_keymanager/) | 17.0.0.0.0 |  | G2P Encryption: Keymanager
-[g2p_encryption_rest_api](g2p_encryption_rest_api/) | 17.0.0.0.0 |  | G2P Encryption: Rest API
-[g2p_enumerator](g2p_enumerator/) | 17.0.0.0.0 |  | G2P Enumerator
-[g2p_mts](g2p_mts/) | 17.0.0.0.0 |  | OpenG2P Registry MTS Connector
-[g2p_odk_importer](g2p_odk_importer/) | 17.0.0.0.0 |  | Import records from ODK
-[g2p_odk_user_mapping](g2p_odk_user_mapping/) | 17.0.0.0.0 |  | ODK App User Mapping
-[g2p_openid_vci](g2p_openid_vci/) | 17.0.0.0.0 |  | G2P OpenID VCI: Base
-[g2p_openid_vci_rest_api](g2p_openid_vci_rest_api/) | 17.0.0.0.0 |  | G2P OpenID VCI: Rest API
-[g2p_portal_auth](g2p_portal_auth/) | 17.0.0.0.0 |  | G2P Portal Auth
-[g2p_profile_image](g2p_profile_image/) | 17.0.0.0.0 |  | OpenG2P Profile Image
-[g2p_registry_addl_info](g2p_registry_addl_info/) | 17.0.0.0.0 |  | G2P Registry: Additional Info
-[g2p_registry_base](g2p_registry_base/) | 17.0.0.0.0 |  | G2P Registry: Base
-[g2p_registry_documents](g2p_registry_documents/) | 17.0.0.0.0 |  | G2P Registry: Documents
-[g2p_registry_encryption](g2p_registry_encryption/) | 17.0.0.0.0 |  | G2P Registry: Encryption
-[g2p_registry_group](g2p_registry_group/) | 17.0.0.0.0 |  | G2P Registry: Groups
-[g2p_registry_individual](g2p_registry_individual/) | 17.0.0.0.0 |  | G2P Registry: Individual
-[g2p_registry_membership](g2p_registry_membership/) | 17.0.0.0.0 |  | G2P Registry: Membership
-[g2p_registry_rest_api](g2p_registry_rest_api/) | 17.0.0.0.0 |  | G2P Registry: Rest API
-[g2p_service_provider_beneficiary_management](g2p_service_provider_beneficiary_management/) | 17.0.0.0.0 |  | G2P Service Provider Beneficiary Management
-[g2p_service_provider_portal_base](g2p_service_provider_portal_base/) | 17.0.0.0.0 |  | G2P Service Provider Portal: Base
-[g2p_superset_dashboard](g2p_superset_dashboard/) | 17.0.0.0.0 |  | OpenG2P Superset Dashboard
-[mts_connector](mts_connector/) | 17.0.0.0.0 |  | MTS Connector
+[g2p_auth_id_oidc](g2p_auth_id_oidc/) | 17.0.1.2.1 |  | G2P Auth: OIDC - Reg ID
+[g2p_auth_oidc](g2p_auth_oidc/) | 17.0.1.2.1 |  | OpenID Connect Authentication
+[g2p_bank](g2p_bank/) | 17.0.1.2.1 |  | G2P Registry: Bank Details
+[g2p_bank_rest_api](g2p_bank_rest_api/) | 17.0.1.2.1 |  | G2P Registry: Bank Details Rest API
+[g2p_change_log](g2p_change_log/) | 17.0.1.2.1 |  | OpenG2P Change Log
+[g2p_disable_password_login](g2p_disable_password_login/) | 17.0.1.2.1 |  | Disable Password Login
+[g2p_documents](g2p_documents/) | 17.0.1.2.1 |  | G2P Documents Store
+[g2p_encryption](g2p_encryption/) | 17.0.1.2.1 |  | G2P Encryption: Base
+[g2p_encryption_keymanager](g2p_encryption_keymanager/) | 17.0.1.2.1 |  | G2P Encryption: Keymanager
+[g2p_encryption_rest_api](g2p_encryption_rest_api/) | 17.0.1.2.1 |  | G2P Encryption: Rest API
+[g2p_enumerator](g2p_enumerator/) | 17.0.1.2.1 |  | G2P Enumerator
+[g2p_mts](g2p_mts/) | 17.0.1.2.1 |  | OpenG2P Registry MTS Connector
+[g2p_odk_importer](g2p_odk_importer/) | 17.0.1.2.1 |  | Import records from ODK
+[g2p_odk_user_mapping](g2p_odk_user_mapping/) | 17.0.1.2.1 |  | ODK App User Mapping
+[g2p_openid_vci](g2p_openid_vci/) | 17.0.1.2.1 |  | G2P OpenID VCI: Base
+[g2p_openid_vci_rest_api](g2p_openid_vci_rest_api/) | 17.0.1.2.1 |  | G2P OpenID VCI: Rest API
+[g2p_portal_auth](g2p_portal_auth/) | 17.0.1.2.1 |  | G2P Portal Auth
+[g2p_profile_image](g2p_profile_image/) | 17.0.1.2.1 |  | OpenG2P Profile Image
+[g2p_registry_addl_info](g2p_registry_addl_info/) | 17.0.1.2.1 |  | G2P Registry: Additional Info
+[g2p_registry_base](g2p_registry_base/) | 17.0.1.2.1 |  | G2P Registry: Base
+[g2p_registry_documents](g2p_registry_documents/) | 17.0.1.2.1 |  | G2P Registry: Documents
+[g2p_registry_encryption](g2p_registry_encryption/) | 17.0.1.2.1 |  | G2P Registry: Encryption
+[g2p_registry_group](g2p_registry_group/) | 17.0.1.2.1 |  | G2P Registry: Groups
+[g2p_registry_individual](g2p_registry_individual/) | 17.0.1.2.1 |  | G2P Registry: Individual
+[g2p_registry_membership](g2p_registry_membership/) | 17.0.1.2.1 |  | G2P Registry: Membership
+[g2p_registry_rest_api](g2p_registry_rest_api/) | 17.0.1.2.1 |  | G2P Registry: Rest API
+[g2p_service_provider_beneficiary_management](g2p_service_provider_beneficiary_management/) | 17.0.1.2.1 |  | G2P Service Provider Beneficiary Management
+[g2p_service_provider_portal_base](g2p_service_provider_portal_base/) | 17.0.1.2.1 |  | G2P Service Provider Portal: Base
+[g2p_superset_dashboard](g2p_superset_dashboard/) | 17.0.1.2.1 |  | OpenG2P Superset Dashboard
+[mts_connector](mts_connector/) | 17.0.1.2.1 |  | MTS Connector
 
 
 Unported addons
 ---------------
 addon | version | maintainers | summary
 --- | --- | --- | ---
-[g2p_registry_addl_info_rest_api](g2p_registry_addl_info_rest_api/) | 17.0.0.0.0 (unported) |  | G2P Registry: Additional Info REST API
-[g2p_registry_rest_api_extension_demo](g2p_registry_rest_api_extension_demo/) | 17.0.0.0.0 (unported) |  | G2P Registry: Rest API Extension Demo
+[g2p_registry_addl_info_rest_api](g2p_registry_addl_info_rest_api/) | 17.0.1.2.1 (unported) |  | G2P Registry: Additional Info REST API
+[g2p_registry_rest_api_extension_demo](g2p_registry_rest_api_extension_demo/) | 17.0.1.2.1 (unported) |  | G2P Registry: Rest API Extension Demo
 
 [//]: # (end addons)
 

--- a/g2p_auth_id_oidc/__manifest__.py
+++ b/g2p_auth_id_oidc/__manifest__.py
@@ -2,9 +2,9 @@
 {
     "name": "G2P Auth: OIDC - Reg ID",
     "category": "G2P",
-    "version": "17.0.0.0.0",
+    "version": "17.0.1.2.1",
     "sequence": 1,
-    "author": "OpenG2P",
+    "author": "OpenG2P (OpenSPP fork)",
     "website": "https://openg2p.org",
     "license": "LGPL-3",
     "depends": ["g2p_auth_oidc", "g2p_registry_individual", "g2p_registry_group"],

--- a/g2p_auth_oidc/__manifest__.py
+++ b/g2p_auth_oidc/__manifest__.py
@@ -1,7 +1,7 @@
 {
     "name": "OpenID Connect Authentication",
-    "version": "17.0.0.0.0",
-    "author": "OpenG2P",
+    "version": "17.0.1.2.1",
+    "author": "OpenG2P (OpenSPP fork)",
     "website": "https://openg2p.org",
     "license": "LGPL-3",
     "external_dependencies": {"python": ["python-jose"]},

--- a/g2p_bank/__manifest__.py
+++ b/g2p_bank/__manifest__.py
@@ -2,9 +2,9 @@
 {
     "name": "G2P Registry: Bank Details",
     "category": "G2P",
-    "version": "17.0.0.0.0",
+    "version": "17.0.1.2.1",
     "sequence": 1,
-    "author": "OpenG2P",
+    "author": "OpenG2P (OpenSPP fork)",
     "website": "https://openg2p.org",
     "license": "LGPL-3",
     "depends": [

--- a/g2p_bank_rest_api/__manifest__.py
+++ b/g2p_bank_rest_api/__manifest__.py
@@ -2,9 +2,9 @@
 {
     "name": "G2P Registry: Bank Details Rest API",
     "category": "G2P",
-    "version": "17.0.0.0.0",
+    "version": "17.0.1.2.1",
     "sequence": 1,
-    "author": "OpenG2P",
+    "author": "OpenG2P (OpenSPP fork)",
     "website": "https://openg2p.org",
     "license": "LGPL-3",
     "depends": [

--- a/g2p_change_log/__manifest__.py
+++ b/g2p_change_log/__manifest__.py
@@ -1,9 +1,9 @@
 {
     "name": "OpenG2P Change Log",
     "category": "G2P",
-    "version": "17.0.0.0.0",
+    "version": "17.0.1.2.1",
     "sequence": 1,
-    "author": "OpenG2P",
+    "author": "OpenG2P (OpenSPP fork)",
     "website": "https://openg2p.org",
     "license": "LGPL-3",
     # any module necessary for this one to work correctly

--- a/g2p_disable_password_login/__manifest__.py
+++ b/g2p_disable_password_login/__manifest__.py
@@ -1,7 +1,7 @@
 {
     "name": "Disable Password Login",
-    "version": "17.0.0.0.0",
-    "author": "OpenG2P",
+    "version": "17.0.1.2.1",
+    "author": "OpenG2P (OpenSPP fork)",
     "website": "https://openg2p.org",
     "license": "LGPL-3",
     "depends": ["auth_oauth"],

--- a/g2p_documents/__manifest__.py
+++ b/g2p_documents/__manifest__.py
@@ -2,9 +2,9 @@
 {
     "name": "G2P Documents Store",
     "category": "G2P",
-    "version": "17.0.0.0.0",
+    "version": "17.0.1.2.1",
     "sequence": 1,
-    "author": "OpenG2P",
+    "author": "OpenG2P (OpenSPP fork)",
     "website": "https://openg2p.org",
     "license": "LGPL-3",
     "depends": [

--- a/g2p_encryption/__manifest__.py
+++ b/g2p_encryption/__manifest__.py
@@ -1,9 +1,9 @@
 {
     "name": "G2P Encryption: Base",
     "category": "G2P",
-    "version": "17.0.0.0.0",
+    "version": "17.0.1.2.1",
     "sequence": 1,
-    "author": "OpenG2P",
+    "author": "OpenG2P (OpenSPP fork)",
     "website": "https://openg2p.org",
     "license": "LGPL-3",
     "depends": [],

--- a/g2p_encryption_keymanager/__manifest__.py
+++ b/g2p_encryption_keymanager/__manifest__.py
@@ -1,9 +1,9 @@
 {
     "name": "G2P Encryption: Keymanager",
     "category": "G2P",
-    "version": "17.0.0.0.0",
+    "version": "17.0.1.2.1",
     "sequence": 1,
-    "author": "OpenG2P",
+    "author": "OpenG2P (OpenSPP fork)",
     "website": "https://openg2p.org",
     "license": "LGPL-3",
     "depends": [

--- a/g2p_encryption_rest_api/__manifest__.py
+++ b/g2p_encryption_rest_api/__manifest__.py
@@ -6,7 +6,8 @@
     "author": "OpenG2P (OpenSPP fork)",
     "website": "https://openg2p.org",
     "license": "LGPL-3",
-    "depends": ["g2p_encryption", "fastapi"],
+    "depends": ["g2p_encryption"],
+    "external_dependencies": {"python": ["fastapi==0.112.2"]},
     "data": ["data/fastapi_endpoint_security.xml"],
     "assets": {
         "web.assets_backend": [],

--- a/g2p_encryption_rest_api/__manifest__.py
+++ b/g2p_encryption_rest_api/__manifest__.py
@@ -1,9 +1,9 @@
 {
     "name": "G2P Encryption: Rest API",
     "category": "G2P",
-    "version": "17.0.0.0.0",
+    "version": "17.0.1.2.1",
     "sequence": 1,
-    "author": "OpenG2P",
+    "author": "OpenG2P (OpenSPP fork)",
     "website": "https://openg2p.org",
     "license": "LGPL-3",
     "depends": ["g2p_encryption", "fastapi"],

--- a/g2p_enumerator/__manifest__.py
+++ b/g2p_enumerator/__manifest__.py
@@ -1,9 +1,9 @@
 {
     "name": "G2P Enumerator",
     "category": "G2P",
-    "version": "17.0.0.0.0",
+    "version": "17.0.1.2.1",
     "sequence": 1,
-    "author": "OpenG2P",
+    "author": "OpenG2P (OpenSPP fork)",
     "website": "https://openg2p.org",
     "license": "LGPL-3",
     "depends": ["g2p_registry_group", "g2p_registry_individual", "base"],

--- a/g2p_mts/__manifest__.py
+++ b/g2p_mts/__manifest__.py
@@ -1,8 +1,8 @@
 {
     "name": "OpenG2P Registry MTS Connector",
     "category": "MTS",
-    "version": "17.0.0.0.0",
-    "author": "OpenG2P",
+    "version": "17.0.1.2.1",
+    "author": "OpenG2P (OpenSPP fork)",
     "website": "https://openg2p.org",
     "license": "LGPL-3",
     "depends": ["mts_connector", "g2p_registry_base"],

--- a/g2p_odk_importer/__manifest__.py
+++ b/g2p_odk_importer/__manifest__.py
@@ -4,9 +4,9 @@
     "name": "G2P ODK Importer",
     "category": "Connector",
     "summary": "Import records from ODK",
-    "version": "17.0.0.0.0",
+    "version": "17.0.1.2.1",
     "sequence": 3,
-    "author": "OpenG2P",
+    "author": "OpenG2P (OpenSPP fork)",
     "website": "https://openg2p.org",
     "license": "LGPL-3",
     "depends": [

--- a/g2p_odk_user_mapping/__manifest__.py
+++ b/g2p_odk_user_mapping/__manifest__.py
@@ -1,9 +1,9 @@
 {
     "name": "ODK App User Mapping",
     "category": "G2P",
-    "version": "17.0.0.0.0",
+    "version": "17.0.1.2.1",
     "sequence": 1,
-    "author": "OpenG2P",
+    "author": "OpenG2P (OpenSPP fork)",
     "website": "https://openg2p.org",
     "license": "LGPL-3",
     "depends": ["base", "account", "g2p_odk_importer"],

--- a/g2p_openid_vci/__manifest__.py
+++ b/g2p_openid_vci/__manifest__.py
@@ -11,7 +11,7 @@
         "g2p_registry_base",
         "g2p_encryption",
     ],
-    "external_dependencies": {"python": ["cryptography<37", "python-jose", "jq", "PyLD"]},
+    "external_dependencies": {"python": ["cryptography", "python-jose", "jq", "PyLD"]},
     "data": [
         "security/ir.model.access.csv",
         "views/vci_issuers.xml",

--- a/g2p_openid_vci/__manifest__.py
+++ b/g2p_openid_vci/__manifest__.py
@@ -2,9 +2,9 @@
 {
     "name": "G2P OpenID VCI: Base",
     "category": "G2P",
-    "version": "17.0.0.0.0",
+    "version": "17.0.1.2.1",
     "sequence": 1,
-    "author": "OpenG2P",
+    "author": "OpenG2P (OpenSPP fork)",
     "website": "https://openg2p.org",
     "license": "LGPL-3",
     "depends": [

--- a/g2p_openid_vci_rest_api/__manifest__.py
+++ b/g2p_openid_vci_rest_api/__manifest__.py
@@ -1,9 +1,9 @@
 {
     "name": "G2P OpenID VCI: Rest API",
     "category": "G2P",
-    "version": "17.0.0.0.0",
+    "version": "17.0.1.2.1",
     "sequence": 1,
-    "author": "OpenG2P",
+    "author": "OpenG2P (OpenSPP fork)",
     "website": "https://openg2p.org",
     "license": "LGPL-3",
     "depends": [

--- a/g2p_portal_auth/__manifest__.py
+++ b/g2p_portal_auth/__manifest__.py
@@ -2,9 +2,9 @@
 {
     "name": "G2P Portal Auth",
     "category": "G2P",
-    "version": "17.0.0.0.0",
+    "version": "17.0.1.2.1",
     "sequence": 1,
-    "author": "OpenG2P",
+    "author": "OpenG2P (OpenSPP fork)",
     "website": "https://openg2p.org",
     "license": "LGPL-3",
     "depends": ["g2p_auth_oidc"],

--- a/g2p_profile_image/__manifest__.py
+++ b/g2p_profile_image/__manifest__.py
@@ -2,9 +2,9 @@
 {
     "name": "OpenG2P Profile Image",
     "category": "G2P",
-    "version": "17.0.0.0.0",
+    "version": "17.0.1.2.1",
     "sequence": 1,
-    "author": "OpenG2P",
+    "author": "OpenG2P (OpenSPP fork)",
     "website": "https://openg2p.org",
     "license": "LGPL-3",
     "depends": [

--- a/g2p_registry_addl_info/__manifest__.py
+++ b/g2p_registry_addl_info/__manifest__.py
@@ -1,9 +1,9 @@
 {
     "name": "G2P Registry: Additional Info",
     "category": "G2P",
-    "version": "17.0.0.0.0",
+    "version": "17.0.1.2.1",
     "sequence": 1,
-    "author": "OpenG2P",
+    "author": "OpenG2P (OpenSPP fork)",
     "website": "https://openg2p.org",
     "license": "LGPL-3",
     "depends": [

--- a/g2p_registry_addl_info_rest_api/__manifest__.py
+++ b/g2p_registry_addl_info_rest_api/__manifest__.py
@@ -1,9 +1,9 @@
 {
     "name": "G2P Registry: Additional Info REST API",
     "category": "G2P",
-    "version": "17.0.0.0.0",
+    "version": "17.0.1.2.1",
     "sequence": 1,
-    "author": "OpenG2P",
+    "author": "OpenG2P (OpenSPP fork)",
     "website": "https://openg2p.org",
     "license": "LGPL-3",
     "depends": ["g2p_registry_rest_api", "g2p_registry_addl_info"],

--- a/g2p_registry_base/__manifest__.py
+++ b/g2p_registry_base/__manifest__.py
@@ -2,9 +2,9 @@
 {
     "name": "G2P Registry: Base",
     "category": "G2P",
-    "version": "17.0.0.0.0",
+    "version": "17.0.1.2.1",
     "sequence": 1,
-    "author": "OpenG2P",
+    "author": "OpenG2P (OpenSPP fork)",
     "website": "https://openg2p.org",
     "license": "LGPL-3",
     "depends": ["base", "mail", "contacts", "web", "portal"],

--- a/g2p_registry_documents/__manifest__.py
+++ b/g2p_registry_documents/__manifest__.py
@@ -2,9 +2,9 @@
 {
     "name": "G2P Registry: Documents",
     "category": "G2P",
-    "version": "17.0.0.0.0",
+    "version": "17.0.1.2.1",
     "sequence": 1,
-    "author": "OpenG2P",
+    "author": "OpenG2P (OpenSPP fork)",
     "website": "https://openg2p.org",
     "license": "LGPL-3",
     "depends": [

--- a/g2p_registry_encryption/__manifest__.py
+++ b/g2p_registry_encryption/__manifest__.py
@@ -1,9 +1,9 @@
 {
     "name": "G2P Registry: Encryption",
     "category": "G2P",
-    "version": "17.0.0.0.0",
+    "version": "17.0.1.2.1",
     "sequence": 1,
-    "author": "OpenG2P",
+    "author": "OpenG2P (OpenSPP fork)",
     "website": "https://openg2p.org",
     "license": "LGPL-3",
     "depends": ["g2p_encryption", "g2p_registry_base", "g2p_registry_individual"],

--- a/g2p_registry_group/__manifest__.py
+++ b/g2p_registry_group/__manifest__.py
@@ -2,9 +2,9 @@
 {
     "name": "G2P Registry: Groups",
     "category": "G2P",
-    "version": "17.0.0.0.0",
+    "version": "17.0.1.2.1",
     "sequence": 1,
-    "author": "OpenG2P",
+    "author": "OpenG2P (OpenSPP fork)",
     "website": "https://openg2p.org",
     "license": "LGPL-3",
     "depends": ["base", "mail", "contacts", "g2p_registry_base"],

--- a/g2p_registry_individual/__manifest__.py
+++ b/g2p_registry_individual/__manifest__.py
@@ -2,9 +2,9 @@
 {
     "name": "G2P Registry: Individual",
     "category": "G2P",
-    "version": "17.0.0.0.0",
+    "version": "17.0.1.2.1",
     "sequence": 1,
-    "author": "OpenG2P",
+    "author": "OpenG2P (OpenSPP fork)",
     "website": "https://openg2p.org",
     "license": "LGPL-3",
     "depends": ["base", "mail", "contacts", "g2p_registry_base"],

--- a/g2p_registry_membership/__manifest__.py
+++ b/g2p_registry_membership/__manifest__.py
@@ -2,9 +2,9 @@
 {
     "name": "G2P Registry: Membership",
     "category": "G2P",
-    "version": "17.0.0.0.0",
+    "version": "17.0.1.2.1",
     "sequence": 1,
-    "author": "OpenG2P",
+    "author": "OpenG2P (OpenSPP fork)",
     "website": "https://openg2p.org",
     "license": "LGPL-3",
     "depends": [

--- a/g2p_registry_rest_api/__manifest__.py
+++ b/g2p_registry_rest_api/__manifest__.py
@@ -2,9 +2,9 @@
 {
     "name": "G2P Registry: Rest API",
     "category": "G2P",
-    "version": "17.0.0.0.0",
+    "version": "17.0.1.2.1",
     "sequence": 1,
-    "author": "OpenG2P",
+    "author": "OpenG2P (OpenSPP fork)",
     "website": "https://openg2p.org",
     "license": "LGPL-3",
     "depends": [

--- a/g2p_registry_rest_api_extension_demo/__manifest__.py
+++ b/g2p_registry_rest_api_extension_demo/__manifest__.py
@@ -2,9 +2,9 @@
 {
     "name": "G2P Registry: Rest API Extension Demo",
     "category": "G2P",
-    "version": "17.0.0.0.0",
+    "version": "17.0.1.2.1",
     "sequence": 1,
-    "author": "OpenG2P",
+    "author": "OpenG2P (OpenSPP fork)",
     "website": "https://openg2p.org",
     "license": "LGPL-3",
     "depends": [

--- a/g2p_service_provider_beneficiary_management/__manifest__.py
+++ b/g2p_service_provider_beneficiary_management/__manifest__.py
@@ -1,9 +1,9 @@
 {
     "name": "G2P Service Provider Beneficiary Management",
     "category": "G2P",
-    "version": "17.0.0.0.0",
+    "version": "17.0.1.2.1",
     "sequence": 1,
-    "author": "OpenG2P",
+    "author": "OpenG2P (OpenSPP fork)",
     "website": "https://openg2p.org",
     "license": "LGPL-3",
     "depends": [

--- a/g2p_service_provider_portal_base/__manifest__.py
+++ b/g2p_service_provider_portal_base/__manifest__.py
@@ -1,9 +1,9 @@
 {
     "name": "G2P Service Provider Portal: Base",
     "category": "OpenG2P",
-    "version": "17.0.0.0.0",
+    "version": "17.0.1.2.1",
     "sequence": 1,
-    "author": "OpenG2P",
+    "author": "OpenG2P (OpenSPP fork)",
     "website": "https://openg2p.org",
     "license": "LGPL-3",
     "depends": ["account", "website"],

--- a/g2p_superset_dashboard/__manifest__.py
+++ b/g2p_superset_dashboard/__manifest__.py
@@ -2,9 +2,9 @@
 {
     "name": "OpenG2P Superset Dashboard",
     "category": "G2P",
-    "version": "17.0.0.0.0",
+    "version": "17.0.1.2.1",
     "sequence": 1,
-    "author": "OpenG2P",
+    "author": "OpenG2P (OpenSPP fork)",
     "website": "https://openg2p.org",
     "license": "LGPL-3",
     "depends": ["base", "web"],

--- a/mts_connector/__manifest__.py
+++ b/mts_connector/__manifest__.py
@@ -1,9 +1,9 @@
 {
     "name": "MTS Connector",
     "category": "MTS",
-    "version": "17.0.0.0.0",
+    "version": "17.0.1.2.1",
     "sequence": 1,
-    "author": "OpenG2P",
+    "author": "OpenG2P (OpenSPP)",
     "website": "https://openg2p.org",
     "license": "LGPL-3",
     "depends": ["base", "queue_job"],

--- a/mts_connector/__manifest__.py
+++ b/mts_connector/__manifest__.py
@@ -3,7 +3,7 @@
     "category": "MTS",
     "version": "17.0.1.2.1",
     "sequence": 1,
-    "author": "OpenG2P (OpenSPP)",
+    "author": "OpenG2P (OpenSPP fork)",
     "website": "https://openg2p.org",
     "license": "LGPL-3",
     "depends": ["base", "queue_job"],

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ boto3
 cryptography
 cryptography<37
 extendable-pydantic
+fastapi==0.112.2
 jq
 jwcrypto
 pydantic

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 PyLD
 boto3
 cryptography
+cryptography<37
 extendable-pydantic
 jq
 jwcrypto


### PR DESCRIPTION
To allow OpenSPP QA and users to understand if they installed an addon from this fork, author is suffixed with "(OpenSPP)", and the addon version is set to match the version of OpenSPP.