### PR TITLE
fix write, added loop for multiple records

### DIFF
--- a/g2p_registry_membership/models/group.py
+++ b/g2p_registry_membership/models/group.py
@@ -30,11 +30,12 @@ class G2PMembershipGroup(models.Model):
     def write(self, values):
         res = super().write(values)
         if self:
-            unique_kinds = self.env["g2p.group.membership.kind"].search([("is_unique", "=", True)])
-            for unique_kind in unique_kinds:
-                count = sum(1 for rec in self.group_membership_ids if unique_kind.id in rec.kind.ids)
-                if count > 1:
-                    raise ValidationError(_("Only one %s is allowed per group") % unique_kind.name)
+            for rec in self:
+                unique_kinds = self.env["g2p.group.membership.kind"].search([("is_unique", "=", True)])
+                for unique_kind in unique_kinds:
+                    count = sum(1 for member in rec.group_membership_ids if unique_kind.id in member.kind.ids)
+                    if count > 1:
+                        raise ValidationError(_("Only one %s is allowed per group") % unique_kind.name)
         return res
 
     @api.model


### PR DESCRIPTION
## **Why is this change needed?**
To fix the problem when writing (specifically archiving) on res partner records. 

## **How was the change implemented?**
Added a loop on multiple records on write to not sum all selected records' membership kind.

## **New unit tests**
```
None
```

## **Unit tests executed by the author**
```
None
```

## **How to test manually**
- Install or upgrade `g2p_registry_membership`
- Archive multiple groups (make sure at least 2 of selected groups have head member)

## **Related links**
https://github.com/OpenSPP/openspp-modules/issues/637